### PR TITLE
Add `map_location` for cpu inference

### DIFF
--- a/hsemotion/facial_emotions.py
+++ b/hsemotion/facial_emotions.py
@@ -46,7 +46,10 @@ class HSEmotionRecognizer:
         )
         
         path=get_model_path(model_name)
-        model=torch.load(path)
+        if device == 'cpu':
+            model=torch.load(path, map_location=torch.device('cpu'))
+        else:
+            model=torch.load(path)
         if isinstance(model.classifier,torch.nn.Sequential):
             self.classifier_weights=model.classifier[0].weight.cpu().data.numpy()
             self.classifier_bias=model.classifier[0].bias.cpu().data.numpy()


### PR DESCRIPTION
Probably it is not a bug for the current models, but I hacked this script locally to run some other models (e.g. [state_vggface2_enet0_new.pt](https://github.com/HSE-asavchenko/face-emotion-recognition/blob/main/models/pretrained_faces/state_vggface2_enet0_new.pt)). And I wasn't able to run it because of the following error:
```
Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```
Using `map_location` should help to avoid such problem.